### PR TITLE
Make options protected instead of private

### DIFF
--- a/Fetch.ts
+++ b/Fetch.ts
@@ -9,7 +9,7 @@ class FetchEx extends Error {
 }
 
 export class Fetch {
-    private readonly _options: Https.RequestOptions;
+    protected readonly _options: Https.RequestOptions;
 
     constructor(url: string, timeoutMS = 10000) {
         const temp = Url.parse(url);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "planck-http-fetch",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Simple http/https fetch",
   "main": "Fetch.js",
   "types": "Fetch.d.ts",


### PR DESCRIPTION
In order to ease extending and mocking this class in unit tests, options should be protected to allow reading them in extensions.